### PR TITLE
Add Laravel 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "laravel/nova": "^4.0",
         "romanzipp/laravel-queue-monitor": "^5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "laravel/framework": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "laravel/framework": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "phpstan/phpstan": "^0.12.99|^1.0",
         "phpunit/phpunit": "^8.5.23|^9.0",
         "romanzipp/php-cs-fixer-config": "^3.0"


### PR DESCRIPTION
Hello,

Laravel 11 is not supported according to the `composer.json` file.

Updating those lines should do the trick